### PR TITLE
(CHROME) Added onclick handler to freeze current measurement.

### DIFF
--- a/extension/tooltip.chrome.js
+++ b/extension/tooltip.chrome.js
@@ -20,6 +20,7 @@ function init(){
 
   window.addEventListener('keydown', detectAltKeyPress);
   window.addEventListener('keyup', detectAltKeyRelease);
+  window.addEventListener('mousedown', detectMouseDown);
 
   disableCursor();
   requestNewScreenshot();
@@ -104,16 +105,26 @@ function destroy(){
   window.removeEventListener('mousemove', onInputMove);
   window.removeEventListener('touchmove', onInputMove);
   window.removeEventListener('scroll', onVisibleAreaChange);
+  window.removeEventListener('mousedown', detectMouseDown);
 
   removeDebugScreen();
-  removeDimensions();
+  removeDimensions(true);
   enableCursor();
 }
 
-function removeDimensions(){
+function removeDimensions(destroyFrozen){
   var dimensions = body.querySelector('.fn-dimensions');
   if(dimensions)
     body.removeChild(dimensions);
+
+  if (destroyFrozen) {
+      var dimensionsFrozen = body.querySelectorAll('.fn-dimensions-frozen');
+      if (dimensionsFrozen) {
+          dimensionsFrozen.forEach(function (elem) {
+              body.removeChild(elem);
+          });
+      }
+  }
 }
 
 function onVisibleAreaChange(){
@@ -298,6 +309,14 @@ function rgbToHsl(r, g, b){
   }
 
   return [h, s, l];
+}
+
+function detectMouseDown(event) {
+    var dimensions = body.querySelector('.fn-dimensions');
+    if (dimensions) {
+        dimensions.classList.remove('fn-dimensions');
+        dimensions.classList.add('fn-dimensions-frozen');
+    }
 }
 
 init();

--- a/extension/tooltip.css
+++ b/extension/tooltip.css
@@ -8,7 +8,7 @@
   z-index: 999999;
 }
 
-.fn-dimensions {
+.fn-dimensions, .fn-dimensions-frozen {
   position: fixed;
   width: 0;
   height: 0;


### PR DESCRIPTION
Added freeze ability so we can compare/screenshot multiple measurements
at the same time.

Single click will freeze/lock current lines/tooltip, and allow you continue to other areas with a new set of lines/tooltip.

Chrome only.