### PR TITLE
Bump z-indexes up two digits

### DIFF
--- a/extension/tooltip.css
+++ b/extension/tooltip.css
@@ -5,14 +5,14 @@
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 999999;
+  z-index: 9999999;
 }
 
 .fn-dimensions {
   position: fixed;
   width: 0;
   height: 0;
-  z-index: 9999;
+  z-index: 999999;
   pointer-events: none;
 }
 
@@ -20,7 +20,7 @@
   position: fixed;
   left: 0;
   top: 0;
-  z-index: 999;
+  z-index: 99999;
 }
 
 .fn-debugScreen.is-hidden {


### PR DESCRIPTION
Depending on how a website is structured, a `z-index` of `9999` might not be enought to display the extension above everything else.