### PR TITLE
Allow closing the overlay with ESC

### DIFF
--- a/extension/chrome.js
+++ b/extension/chrome.js
@@ -143,6 +143,9 @@ var dimensions = {
         case 'take screenshot':
           this.takeScreenshot();
           break;
+        case 'close_overlay':
+          this.deactivate();
+          break;
       }
     }
   },

--- a/extension/tooltip.chrome.js
+++ b/extension/tooltip.chrome.js
@@ -20,6 +20,7 @@ function init(){
 
   window.addEventListener('keydown', detectAltKeyPress);
   window.addEventListener('keyup', detectAltKeyRelease);
+  window.addEventListener('keyup', onKeyRelease);
 
   disableCursor();
   requestNewScreenshot();
@@ -163,6 +164,14 @@ function detectAltKeyRelease(event){
     altKeyWasPressed = false;
     sendToWorker(event);
     hideDebugScreen();
+  }
+}
+
+function onKeyRelease(event) {
+  switch (event.code) {
+    case 'Escape':
+      port.postMessage({ type: 'close_overlay' });
+    break;
   }
 }
 


### PR DESCRIPTION
This commit addresses issue https://github.com/mrflix/dimensions/issues/36 and implements closing of the overlay by pressing ESC.